### PR TITLE
Use the public url for the repo instead of the private one

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Git and pathogen
 ----------------
 
     $ cd ~/.vim/bundle
-    $ git clone https://hail2u@github.com/hail2u/vim-css3-syntax.git
+    $ git clone https://github.com/hail2u/vim-css3-syntax.git
 
 
 With HTML file


### PR DESCRIPTION
Before this commit, if you follow install instructions the output of git is:

``` bash
$ git clone https://hail2u@github.com/hail2u/vim-css3-syntax.git
Cloning into vim-css3-syntax...
Password: 
```
