### PR TITLE
Add 'numeric' keyword for 'system' prop.

### DIFF
--- a/after/syntax/css/css-counter-styles-3.vim
+++ b/after/syntax/css/css-counter-styles-3.vim
@@ -3,7 +3,7 @@ syn region cssInclude start=/@counter-style\>/ end=/\ze{/ skipwhite skipnl conta
 syn keyword cssGeneratedContentProp contained system negative prefix suffix range pad fallback
 syn match cssGeneratedContentProp contained "\<\(additive-\)\=symbols\>"
 syn match cssGeneratedContentProp contained "\<speak-as\>"
-syn keyword cssGeneratedContentAttr contained cyclic symbolic additive extends bullets numbers words
+syn keyword cssGeneratedContentAttr contained cyclic numeric symbolic additive extends bullets numbers words
 syn match cssGeneratedContentAttr contained "\<cjk-decimal\>"
 syn match cssGeneratedContentAttr contained "\<disclosure-\(open\|closed\)\>"
 syn match cssGeneratedContentAttr contained "\<simp-chinese-\(in\)\=formal\>"

--- a/test/test.css
+++ b/test/test.css
@@ -121,6 +121,7 @@
   display: symbols("*" "\2020" "\2021" "\A7");
   display: bullets;
   display: words;
+  display: numeric;
 }
 
 .display {

--- a/test/test.html
+++ b/test/test.html
@@ -131,6 +131,7 @@
         display: symbols("*" "\2020" "\2021" "\A7");
         display: bullets;
         display: words;
+        display: numeric;
       }
 
       .display {


### PR DESCRIPTION
With Vim 7.4.640, the keyword seems not to be treated by neither Vim's css.vim nor this extension.