### PR TITLE
Add webvtt1.vim

### DIFF
--- a/after/syntax/css/webvtt1.vim
+++ b/after/syntax/css/webvtt1.vim
@@ -1,0 +1,2 @@
+syn match cssPseudoClassId contained "::\<cue\(-region\)\=\>"
+syn region cssPseudoClassLang matchgroup=cssPseudoClassId start="::cue\(-region\)\=(" end=")" oneline

--- a/after/syntax/html.vim
+++ b/after/syntax/html.vim
@@ -76,4 +76,5 @@ syn include @htmlCss syntax/css/selectors.vim
 syn include @htmlCss syntax/css/selectors4.vim
 syn include @htmlCss syntax/css/svg2.vim
 syn include @htmlCss syntax/css/web-animations-1.vim
+syn include @htmlCss syntax/css/webvtt1.vim
 syn include @htmlCss syntax/css/worklets-1.vim

--- a/test/test.css
+++ b/test/test.css
@@ -871,6 +871,13 @@
   display: auto;
 }
 
+.webvtt1::cue,
+.webvtt1::cue-region,
+.webvtt1::cue(#cue1),
+.webvtt1::cue-region(#scroll), {
+  display: auto;
+}
+
 .will-change-1 {
   will-change: scroll-position;
 }

--- a/test/test.html
+++ b/test/test.html
@@ -951,6 +951,14 @@
 }
 </style>
 <style>
+.webvtt1::cue,
+.webvtt1::cue-region,
+.webvtt1::cue(#cue1),
+.webvtt1::cue-region(#scroll), {
+  display: auto;
+}
+</style>
+<style>
 .will-change-1 {
   will-change: scroll-position;
 }


### PR DESCRIPTION
This syntax file is for WebVTT: The Web Video Text Tracks Format.

This resolves part of #55. `:past` and `:future` is not support, because
they are used only in parentheses of `cue()`, and current CSS syntax
does not support a highlighting in parentheses of pseudo functions.