### PR TITLE
Follow changes in the default runtime files

### DIFF
--- a/after/syntax/css/cascade-3.vim
+++ b/after/syntax/css/cascade-3.vim
@@ -1,2 +1,0 @@
-syn keyword cssFontProp all
-syn keyword cssCommonAttr contained initial unset

--- a/after/syntax/css/display-3.vim
+++ b/after/syntax/css/display-3.vim
@@ -1,3 +1,2 @@
 syn keyword cssFontAttr contained contents discard
-syn match cssFontAttr contained "\<flow\(-root\)\=\>"
 syn match cssBoxAttr contained "\<ruby\(-\(base\(-group\)\=\|text\(-group\)\=\)\)\=\>"

--- a/after/syntax/css/grid-1.vim
+++ b/after/syntax/css/grid-1.vim
@@ -1,5 +1,3 @@
-syn match cssFontProp contained "\<grid-template\>"
 syn keyword cssFontAttr contained dense span
 syn match cssFontAttr contained "\<auto-flow\>"
-syn match cssValueNumber contained "[01]\(.\d\+\)\=fr"
 syn region cssFunction contained matchgroup=cssFunctionName start="\<\(minmax\|repeat\)\s*(" end=")" oneline keepend

--- a/after/syntax/css/text-3.vim
+++ b/after/syntax/css/text-3.vim
@@ -1,9 +1,6 @@
-syn keyword cssTextProp contained hyphens
-syn match cssTextProp contained "\<line-break\>"
-syn match cssTextProp contained "\<overflow-wrap\>"
 syn match cssTextProp contained "\<tab-size\>"
 syn match cssTextProp contained "\<text-align-all\>"
-syn keyword cssTextAttr contained manual loose strict hanging anywhere
+syn keyword cssTextAttr contained loose strict hanging anywhere
 syn match cssTextAttr contained "\<match-parent\>"
 syn match cssTextAttr contained "\<each-line\>"
 syn match cssTextAttr contained "\<full-width\>"

--- a/after/syntax/css/values-3.vim
+++ b/after/syntax/css/values-3.vim
@@ -1,3 +1,2 @@
-syn match cssValueLength contained "[-+]\=\d\+\(\.\d*\)\=\(ch\|vw\|vh\|vmin\|vmax\|q\)"
+syn match cssValueLength contained "[-+]\=\d\+\(\.\d*\)\=\(ch\|q\)"
 syn match cssValueAngle contained "[-+]\=\d\+\(\.\d*\)\=turn"
-syn region cssFunction contained matchgroup=cssFunctionName start="\<calc\s*(" end=")" oneline keepend

--- a/after/syntax/css/variables-1.vim
+++ b/after/syntax/css/variables-1.vim
@@ -1,2 +1,0 @@
-syn match cssFontProp contained "\<--[A-Za-z_][A-Za-z0-9_-]\+\>"
-syn region cssFunction contained matchgroup=cssFunctionName start="\<var\s*(" end=")" oneline keepend

--- a/test/test.css
+++ b/test/test.css
@@ -72,9 +72,7 @@
 }
 
 .cascade-3 {
-  all: auto;
-  display: initial;
-  display: unset;
+  display: auto;
 }
 
 .cascade-4 {
@@ -241,8 +239,6 @@
 }
 
 .display-3 {
-  display: flow;
-  display: flow-root;
   display: contents;
   display: ruby;
   display: ruby-base;
@@ -410,10 +406,8 @@
 }
 
 .grid-1 {
-  grid-template: auto;
   display: minmax(0, 1);
   display: repeat(4);
-  display: 0.2fr;
   display: dense;
   display: auto-flow;
   display: span;
@@ -968,12 +962,8 @@ view {
 }
 
 .text-3 {
-  hyphens: auto;
-  line-break: auto;
-  overflow-wrap: auto;
   tab-size: auto;
   text-align-all: auto;
-  display: manual;
   display: loose;
   display: strict;
   display: match-parent;
@@ -1091,12 +1081,8 @@ view {
 
 .values-3 {
   display: 1ch;
-  display: 1vw;
-  display: 1vh;
-  display: 1vmin;
   display: 1q;
   display: 1turn;
-  display: calc(100%/3 - 2*1em - 2*1px);
 }
 
 .values-4 {
@@ -1113,8 +1099,7 @@ view {
 }
 
 .variables-1 {
-  --var-foo: auto;
-  display: var(foo);
+  display: auto;
 }
 
 .web-animations-1 {


### PR DESCRIPTION
These removed syntaxes are included in [runtime files update][1].

Summary of removals:

- Unit: fr, vh, vmax, vmin, vw
- Property: all, grid-template, hyphens, line-break, overflow-wrap, --foo (custom property)
- Attribute: initial, unset, flow, flow-root, manual
- Function: var(), calc() 

[1]: https://github.com/vim/vim/commit/06fe74aef72606ac34c9f494186e52614b8fb59a#diff-613ff34c5d60e41a3fc93fcb58277143