### PR TITLE
Use hyphen in keyword

### DIFF
--- a/after/syntax/css/align-3.vim
+++ b/after/syntax/css/align-3.vim
@@ -1,5 +1,2 @@
-syn match cssFontProp contained "\<place-\(self\|content\|items\)\>"
-syn match cssFontProp contained "\<\(row-\)\=gap\>"
-syn keyword cssFontAttr contained safe unsafe legacy
-syn match cssFontAttr contained "\<self-\(start\|end\)\>"
-syn match cssFontAttr contained "\<space-evenly\>"
+syn keyword cssFontProp contained place-self place-content place-items row-gap
+syn keyword cssFontAttr contained safe unsafe legacy self-start self-end

--- a/after/syntax/css/backgrounds-4.vim
+++ b/after/syntax/css/backgrounds-4.vim
@@ -1,7 +1,2 @@
-syn keyword cssFontProp contained corners
-syn match cssFontProp contained "\<background-position-\(x\|y\|inline\|block\)\>"
-syn match cssFontProp contained "\<corner-shape\>"
-syn match cssFontProp contained "\<border-limit\>"
-syn match cssFontProp contained "\<border-clip\(-\(top\|right\|bottom\|left\)\)\=\>"
-syn keyword cssFontAttr contained bevel scoop notch
-syn match cssFontAttr contained "\<\(x\|y\)-\(start\|end\)\>"
+syn keyword cssFontProp contained background-position-x background-position-y background-position-inline background-position-block corners corner-shape border-limit border-clip border-clip-top border-clip-right border-clip-bottom border-clip-left
+syn keyword cssFontAttr contained x-start x-end y-start y-end bevel scoop notch

--- a/after/syntax/css/box-4.vim
+++ b/after/syntax/css/box-4.vim
@@ -1,2 +1,2 @@
-syn match cssBoxProp contained "\<margin-trim\>"
-syn match cssBoxAttr contained "\<in-flow\>"
+syn keyword cssBoxProp contained margin-trim
+syn keyword cssBoxAttr contained in-flow

--- a/after/syntax/css/break-4.vim
+++ b/after/syntax/css/break-4.vim
@@ -1,2 +1,2 @@
-syn match cssBoxProp contained "\<margin-break\>"
+syn keyword cssBoxProp contained margin-break
 syn keyword cssFontAttr contained keep

--- a/after/syntax/css/cascade-5.vim
+++ b/after/syntax/css/cascade-5.vim
@@ -1,1 +1,1 @@
-syn match cssFontAttr contained "\<revert-layer\>"
+syn keyword cssFontAttr contained revert-layer

--- a/after/syntax/css/color-4.vim
+++ b/after/syntax/css/color-4.vim
@@ -1,4 +1,3 @@
-syn keyword cssFontAttr contained perceptual
-syn match cssFontAttr contained "\<\(relative\|absolute\)-colorimetric\>"
+syn keyword cssFontAttr contained perceptual relative-colorimetric absolute-colorimetric
 syn region cssFunction contained matchgroup=cssFunctionName start="\<\(hwb\|lab\|lch\|color\|device-cmyk\=\)\s*(" end=")" oneline keepend
 syn match cssFontDescriptor "@color-profile\>" nextgroup=cssFontDescriptorBlock skipwhite skipnl

--- a/after/syntax/css/color-adjust-1.vim
+++ b/after/syntax/css/color-adjust-1.vim
@@ -1,3 +1,2 @@
-syn match cssColorProp contained "\<\(forced-\|print-\)\=color-adjust\>"
-syn match cssColorProp contained "\<color-scheme\>"
+syn keyword cssColorProp contained forced-color-adjust print-color-adjust color-adjust color-scheme
 syn keyword cssFontAttr contained economy exact

--- a/after/syntax/css/compositing-1.vim
+++ b/after/syntax/css/compositing-1.vim
@@ -1,3 +1,2 @@
-syn keyword cssFontProp contained isolation
-syn match cssFontProp contained "\<\(mix\|background\)-blend-mode\>"
+syn keyword cssFontProp contained isolation mix-blend-mode background-blend-mode
 syn keyword cssFontAttr contained multiply screen overlay darken lighten color-dodge color-burn hard-light soft-light difference exclusion hue saturation color luminosity

--- a/after/syntax/css/contain-2.vim
+++ b/after/syntax/css/contain-2.vim
@@ -1,1 +1,1 @@
-syn match cssFontProp contained "\<content-visibility\>"
+syn keyword cssFontProp content-visibility

--- a/after/syntax/css/content-3.vim
+++ b/after/syntax/css/content-3.vim
@@ -1,4 +1,3 @@
-syn match cssGeneratedContentProp contained "\<string-set\>"
-syn match cssGeneratedContentProp contained "\<bookmark-\(label\|level\|state\)\>"
+syn keyword cssGeneratedContentProp contained string-set bookmark-label bookmark-level bookmark-state
 syn keyword cssGeneratedContentAttr contained open closed
 syn region cssFunction contained matchgroup=cssFunctionName start="\<\(leader\|string\|target-\(counter\|counters\|text\)\)\s*(" end=")" oneline keepend

--- a/after/syntax/css/counter-styles-3.vim
+++ b/after/syntax/css/counter-styles-3.vim
@@ -1,13 +1,4 @@
-syn keyword cssGeneratedContentProp contained system negative prefix suffix range pad fallback
-syn match cssGeneratedContentProp contained "\<\(additive-\)\=symbols\>"
-syn match cssGeneratedContentProp contained "\<speak-as\>"
-syn keyword cssGeneratedContentAttr contained cyclic symbolic additive extends bullets numbers words bengali cambodian khmer devanagari gujarati gurmukhi kannada lao malayalam mongolian myanmar oriya persian tamil telugu thai tibetan
-syn match cssGeneratedContentAttr contained "\<\(ethiopic-\)\=numeric\>"
-syn match cssGeneratedContentAttr contained "\<arabic-indic\>"
-syn match cssGeneratedContentAttr contained "\<\(upper\|lower\)-armenian\>"
-syn match cssGeneratedContentAttr contained "\<cjk-\(decimal\|earthly-branch\|heavenly-stem\)\>"
-syn match cssGeneratedContentAttr contained "\<disclosure-\(open\|closed\)\>"
-syn match cssGeneratedContentAttr contained "\<\(japanese\|korean-hanja\|\(simp\|trad\)-chinese\)-\(in\)\=formal\>"
-syn match cssGeneratedContentAttr contained "\<korean-hangul-formal\>"
+syn keyword cssGeneratedContentProp contained system negative prefix suffix range pad fallback additive-symbols symbols speak-as
+syn keyword cssGeneratedContentAttr contained cyclic symbolic additive extends bullets numbers words bengali cambodian khmer devanagari gujarati gurmukhi kannada lao malayalam mongolian myanmar oriya persian tamil telugu thai tibetan ethiopic-numeric numeric arabic-indic upper-armenian lower-armenian cjk-decimal cjk-earthly-branch cjk-heavenly-stem disclosure-open disclosure-closed japanese-formal korean-hanja-formal simp-chinese-formal trad-chinese-formal japanese-informal korean-hanja-informal simp-chinese-informal trad-chinese-informal korean-hangul-formal
 syn region cssFunction contained matchgroup=cssFunctionName start="\<symbols\s*(" end=")" oneline keepend
 syn match cssFontDescriptor "@counter-style\>" nextgroup=cssFontDescriptorBlock skipwhite skipnl

--- a/after/syntax/css/cssom-view-1.vim
+++ b/after/syntax/css/cssom-view-1.vim
@@ -1,2 +1,2 @@
-syn match cssFontProp contained "\<scroll-behavior\>"
+syn keyword cssFontProp contained scroll-behavior
 syn keyword cssFontAttr contained smooth

--- a/after/syntax/css/device-adapt-1.vim
+++ b/after/syntax/css/device-adapt-1.vim
@@ -1,2 +1,2 @@
-syn match cssFontProp contained "\<\(min\|max\|user\)-zoom\>"
+syn keyword cssFontProp contained min-zoom max-zoom user-zoom
 syn match cssFontDescriptor "@viewport\>" nextgroup=cssFontDescriptorBlock skipwhite skipnl

--- a/after/syntax/css/display-3.vim
+++ b/after/syntax/css/display-3.vim
@@ -1,3 +1,2 @@
 syn keyword cssFontAttr contained contents discard
-syn match cssBoxAttr contained "\<run-in\>"
-syn match cssBoxAttr contained "\<ruby\(-\(base\|text\)\)\=\>"
+syn keyword cssBoxAttr contained run-in ruby ruby-base ruby-text

--- a/after/syntax/css/exclusions-3.vim
+++ b/after/syntax/css/exclusions-3.vim
@@ -1,3 +1,2 @@
-" TODO: create cssExclusionsProp group and cssExclusionsAttr group
-syn match cssFontProp contained "\<wrap-\(flow\|through\)\>"
+syn keyword cssFontProp contained wrap-flow wrap-through
 syn keyword cssFontAttr contained minimum maximum

--- a/after/syntax/css/fill-stroke-3.vim
+++ b/after/syntax/css/fill-stroke-3.vim
@@ -1,5 +1,2 @@
-syn match cssFontProp contained "\<\(fill\|stroke\)\(-\(break\|color\|image\|origin\|position\|size\|repeat\|opacity\)\)\=\>"
-syn match cssFontProp contained "\<fill-rule\>"
-syn match cssFontProp contained "\<stroke-\(width\|align\|line\(cap\|join\)\|miterlimit\|dash\(array\|offset\)\|dash-\(corner\|justify\)\)\>"
-syn keyword cssFontAttr contained butt arcs stupid compress dashes gaps
-syn match cssFontAttr contained "\<bounding-box\>"
+syn keyword cssFontProp contained fill stroke fill-break fill-color fill-image fill-origin fill-position fill-size fill-repeat fill-opacity stroke-break stroke-color stroke-image stroke-origin stroke-position stroke-size stroke-repeat stroke-opacity fill-rule stroke-width stroke-align stroke-linecap stroke-linejoin stroke-miterlimit stroke-dasharray stroke-dashoffset stroke-dash-corner stroke-dash-justify
+syn keyword cssFontAttr contained butt arcs stupid compress dashes gaps bounding-box

--- a/after/syntax/css/filter-effects-1.vim
+++ b/after/syntax/css/filter-effects-1.vim
@@ -1,5 +1,3 @@
-syn match cssFontProp contained "\<flood-\(color\|opacity\)\>"
-syn match cssFontProp contained "\<color-interpolation-filters\>"
-syn match cssFontProp contained "\<lighting-color\>"
+syn keyword cssFontProp contained flood-color flood-opacity color-interpolation-filters lighting-color
 syn keyword cssFontAttr sRGB linearRGB
 syn region cssFunction contained matchgroup=cssFunctionName start="\<\(blur\|brightness\|contrast\|drop-shadow\|grayscale\|hue-rotate\|invert\|opacity\|saturate\|sepia\)\s*(" end=")" oneline keepend

--- a/after/syntax/css/fonts-3.vim
+++ b/after/syntax/css/fonts-3.vim
@@ -1,10 +1,1 @@
-syn keyword cssFontAttr contained unicase jis78 jis83 jis90 jis04 simplified traditional ordinal
-syn match cssFontAttr contained "\<\(no-\)\=\(common\|discretionary\|historical\)-ligatures\>"
-syn match cssFontAttr contained "\<\(no-\)\=contextual\>"
-syn match cssFontAttr contained "\<all-small-caps\>"
-syn match cssFontAttr contained "\<\(all-\)\=petite-caps\>"
-syn match cssFontAttr contained "\<titling-caps\>"
-syn match cssFontAttr contained "\<\(lining\|oldstyle\|proportional\|tabular\)-nums\>"
-syn match cssFontAttr contained "\<\(diagonal\|stacked\)-fractions\>"
-syn match cssFontAttr contained "\<proportional-width\>"
-syn match cssFontAttr contained "\<slashed-zero\>"
+syn keyword cssFontAttr contained unicase jis78 jis83 jis90 jis04 simplified traditional ordinal no-common-ligatures no-discretionary-ligatures no-historical-ligatures common-ligatures discretionary-ligatures historical-ligatures no-contextual contextual all-small-caps all-petite-caps petite-caps titling-caps lining-nums oldstyle-nums proportional-nums tabular-nums diagonal-fractions stacked-fractions proportional-width slashed-zero

--- a/after/syntax/css/fonts-4.vim
+++ b/after/syntax/css/fonts-4.vim
@@ -1,19 +1,5 @@
-syn match cssFontProp contained "\<font-synthesis\(-\(weight\|style\|small-caps\|settings\)\)\=\>"
-syn match cssFontProp contained "\<font-named-instance\>"
-syn match cssFontProp contained "\<font-display\>"
-syn match cssFontProp contained "\<\(ascent\|descent\|line-gap\)-override\>"
-syn match cssFontProp contained "\<font-optical-sizing\>"
-syn match cssFontProp contained "\<font-variation-settings\>"
-syn match cssFontProp contained "\<font-palette\>"
-syn match cssFontProp contained "\<font-variant-emoji\>"
-syn match cssFontProp contained "\<font-presentation\>"
-syn match cssFontProp contained "\<base-palette\>"
-syn match cssFontProp contained "\<override-color\>"
-syn keyword cssFontAttr contained emoji math fangsong swap fallback light dark
-syn match cssFontAttr contained "\<system-ui\>"
-syn match cssFontAttr contained "\<ui-\(\(sans-\)\=serif\|monospace\|rounded\)\>"
-syn match cssFontAttr contained "\<xxx-large\>"
-syn match cssFontAttr contained "\<historical-forms\>"
+syn keyword cssFontProp contained font-synthesis font-synthesis-weight font-synthesis-style font-synthesis-small-caps font-synthesis-settings font-named-instance font-display ascent-override descent-override line-gap-override font-optical-sizing font-variation-settings font-palette font-variant-emoji font-presentation base-palette override-color
+syn keyword cssFontAttr contained emoji math fangsong swap fallback light dark contained system-ui contained ui-sans-serif ui-serif ui-monospace ui-rounded contained xxx-large contained historical-forms
 syn region cssFunction contained matchgroup=cssFunctionName start="\<\(stylistic\|styleset\|character-variant\|swash\|ornaments\|annotation\)\s*(" end=")" oneline keepend
 syn match cssFontDescriptor "@font-feature-values\>" nextgroup=cssFontDescriptorBlock skipwhite skipnl
 syn match cssFontDescriptor "@font-palette-values\>" nextgroup=cssFontDescriptorBlock skipwhite skipnl

--- a/after/syntax/css/gcpm-3.vim
+++ b/after/syntax/css/gcpm-3.vim
@@ -1,5 +1,4 @@
-syn keyword cssGeneratedContentProp contained running
-syn match cssGeneratedContentProp contained "\<footnote-\(display\|policy\)\>"
+syn keyword cssGeneratedContentProp contained running footnote-display footnote-policy
 syn keyword cssGeneratedContentAttr contained footnote line
 syn region cssFunction contained matchgroup=cssFunctionName start="\<\(element\|running\)\s*(" end=")" oneline keepend
-syn match cssPseudoClassId contained "\<footnote-\(call\|marker\)\>"
+syn keyword cssPseudoClassId contained footnote-call footnote-marker

--- a/after/syntax/css/grid-1.vim
+++ b/after/syntax/css/grid-1.vim
@@ -1,3 +1,2 @@
-syn keyword cssFontAttr contained dense span
-syn match cssFontAttr contained "\<auto-flow\>"
+syn keyword cssFontAttr contained dense span auto-flow
 syn region cssFunction contained matchgroup=cssFunctionName start="\<\(minmax\|repeat\)\s*(" end=")" oneline keepend

--- a/after/syntax/css/html5.vim
+++ b/after/syntax/css/html5.vim
@@ -1,1 +1,1 @@
-syn keyword cssTagName picture rb rtc slot template
+syn keyword cssTagName rb rtc slot template

--- a/after/syntax/css/images-3.vim
+++ b/after/syntax/css/images-3.vim
@@ -1,6 +1,3 @@
-syn match cssFontProp contained "\<object-\(fit\|position\)\>"
-syn match cssFontProp contained "\<image-orientation\>"
-syn keyword cssFontAttr contained snap flip pixelated
-syn match cssFontAttr contained "\<scale-down\>"
-syn match cssFontAttr contained "\<from-image\>"
+syn keyword cssFontProp contained image-orientation
+syn keyword cssFontAttr contained snap flip pixelated from-image
 syn region cssFunction contained matchgroup=cssFunctionName start="\<\(repeating-\(linear\|radial\)-gradient\)\s*(" end=")" oneline keepend

--- a/after/syntax/css/images-4.vim
+++ b/after/syntax/css/images-4.vim
@@ -1,2 +1,2 @@
-syn match cssFontProp contained "\<image-resolution\>"
-syn region cssFunction contained matchgroup=cssFunctionName start="\<\(image\|element\|conic-gradient\)\s*(" end=")" oneline keepend
+syn keyword cssFontProp contained image-resolution
+syn region cssFunction contained matchgroup=cssFunctionName start="\<\(image\|element\)\s*(" end=")" oneline keepend

--- a/after/syntax/css/inline-3.vim
+++ b/after/syntax/css/inline-3.vim
@@ -1,8 +1,2 @@
-syn match cssFontProp contained "\<\(dominant\|alignment\)-baseline\>"
-syn match cssFontProp contained "\<baseline-\(shift\|source\)\>"
-syn match cssFontProp contained "\<text-edge\>"
-syn match cssFontProp contained "\<leading-trim\>"
-syn match cssFontProp contained "\<inline-sizing\>"
-syn match cssFontProp contained "\<initial-letter\(-\(align\|wrap\)\)\=\>"
-syn keyword cssFontAttr contained central mathematical leading cap ex drop raise
-syn match cssFontAttr contained "\<ideographic\(-ink\)\=\>"
+syn keyword cssFontProp contained dominant-baseline alignment-baseline baseline-shift baseline-source text-edge leading-trim inline-sizing initial-letter initial-letter-align initial-letter-wrap
+syn keyword cssFontAttr contained central mathematical leading cap ex drop raise ideographic ideographic-ink

--- a/after/syntax/css/line-grid-1.vim
+++ b/after/syntax/css/line-grid-1.vim
@@ -1,5 +1,2 @@
-syn match cssFontProp contained "\<line-\(grid\|snap\)"
-syn match cssFontProp contained "\<box-snap\>"
-syn keyword cssFontAttr contained create
-syn match cssFontAttr contained "\<block-\(start\|end\)\>"
-syn match cssFontAttr contained "\<\(first\|last\)-baseline\>"
+syn keyword cssFontProp contained line-grid line-snap box-snap
+syn keyword cssFontAttr contained create block-start block-end first-baseline last-baseline

--- a/after/syntax/css/lists-3.vim
+++ b/after/syntax/css/lists-3.vim
@@ -1,7 +1,3 @@
-" WD-css-lists-3-20190817
-syn match cssGeneratedContentProp contained "\<marker-side\>"
-syn match cssGeneratedContentProp contained "\<counter-set\>"
-syn keyword cssGeneratedContentAttr contained marker
-syn match cssGeneratedContentAttr contained "\<match-self\>"
-syn match cssGeneratedContentAttr contained "\<list-container\>"
+syn keyword cssGeneratedContentProp contained marker-side counter-set
+syn keyword cssGeneratedContentAttr contained marker contained match-self contained list-container
 syn region cssFunction contained matchgroup=cssFunctionName start="\<counters\s*(" end=")" oneline keepend

--- a/after/syntax/css/logical-1.vim
+++ b/after/syntax/css/logical-1.vim
@@ -1,5 +1,2 @@
-syn match cssFontProp contained "\<\(\(min\|max\)-\)\=\(block\|inline\)-size\>"
-syn match cssFontProp contained "\<\(margin\|padding\)\(-\(block\|inline\)\(-\(start\|end\)\)\=\)\=\>"
-syn match cssFontProp contained "\<border-\(block\|inline\)\(\(-\(start\|end\)\)\=\(-\(width\|style\|color\)\)\=\)\=\>"
-syn match cssFontProp contained "\<border-\(start\|end\)-\(start\|end\)-radius\>"
+syn keyword cssFontProp contained block-size inline-size min-block-size min-inline-size max-block-size max-inline-size margin-block padding-block margin-block-start padding-block-start margin-block-end padding-block-end margin-inline padding-inline margin-inline-start padding-inline-start margin-inline-end padding-inline-end border-block border-inline border-block-start border-block-end border-inline-start border-inline-end border-block-width border-inline-width border-block-start-width border-block-end-width border-inline-start-width border-inline-end-width border-block-style border-inline-style border-block-start-style border-block-end-style border-inline-start-style border-inline-end-style border-block-color border-inline-color border-block-start-color border-block-end-color border-inline-start-color border-inline-end-color border-start-start-radius border-start-end-radius border-end-start-radius border-end-end-radius
 syn keyword cssFontAttr contained logical physical rotate

--- a/after/syntax/css/masking-1.vim
+++ b/after/syntax/css/masking-1.vim
@@ -1,7 +1,3 @@
-syn match cssFontProp contained "\<clip-\(path\|rule\)\>"
-syn match cssFontProp contained "\<mask\(-\(image\|mode\|repeat\|position\|clip\|origin\|size\|composite\|type\)\)\=\>"
-syn match cssFontProp contained "\<mask-border\(-\(source\|mode\|slice\|width\|outset\|repeat\)\)\=\>"
-syn keyword cssFontAttr contained nonzero evenodd alpha luminance add subtract intersect exclude
-syn match cssFontAttr contained "\<\(fill\|stroke\|view\)-box\>"
-syn match cssFontAttr contained "\<no-clip\>"
-syn match cssTagName "\<mask\>"
+syn keyword cssFontProp contained clip-path clip-rule mask mask-image mask-mode mask-repeat mask-position mask-clip mask-origin mask-size mask-composite mask-type mask-border mask-border-source mask-border-mode mask-border-slice mask-border-width mask-border-outset mask-border-repeat
+syn keyword cssFontAttr contained nonzero evenodd alpha luminance add subtract intersect exclude fill-box stroke-box view-box no-clip
+syn keyword cssTagName mask

--- a/after/syntax/css/motion-1.vim
+++ b/after/syntax/css/motion-1.vim
@@ -1,2 +1,2 @@
-syn match cssFontProp contained "\<offset\(-\(path\|distance\|position\|anchor\|rotate\)\)\=\>"
+syn keyword cssFontProp contained offset offset-path offset-distance offset-position offset-anchor offset-rotate
 syn region cssFunction contained matchgroup=cssFunctionName start="\<\(ray\|path\)\s*(" end=")" oneline keepend

--- a/after/syntax/css/multicol-1.vim
+++ b/after/syntax/css/multicol-1.vim
@@ -1,1 +1,1 @@
-syn match cssFontAttr contained "\<balance\(-all\)\=\>"
+syn keyword cssFontAttr contained balance balance-all

--- a/after/syntax/css/nav-1.vim
+++ b/after/syntax/css/nav-1.vim
@@ -1,2 +1,2 @@
-syn match cssFontProp contained "\<spatial-navigation-\(action\|contain\|function\)\>"
+syn keyword cssFontProp contained spatial-navigation-action spatial-navigation-contain spatial-navigation-function
 syn keyword cssFontAttr contained focus

--- a/after/syntax/css/overflow-3.vim
+++ b/after/syntax/css/overflow-3.vim
@@ -1,6 +1,1 @@
-syn keyword cssFontProp contained continue
-syn match cssFontProp contained "\<overflow-\(clip-margin\|block\|inline\)\>"
-syn match cssFontProp contained "\<scrollbar-gutter\>"
-syn match cssFontProp contained "\<block-ellipsis\>"
-syn match cssFontProp contained "\<line-clamp\>"
-syn match cssFontProp contained "\<max-lines\>"
+syn keyword cssFontProp contained continue overflow-clip-margin overflow-block overflow-inline scrollbar-gutter block-ellipsis line-clamp max-lines

--- a/after/syntax/css/overscroll-1.vim
+++ b/after/syntax/css/overscroll-1.vim
@@ -1,1 +1,1 @@
-syn match cssFontProp contained "\<overscroll-behavior\(-\(block\|inline\|x\|y\)\)\=\>"
+syn keyword cssFontProp contained overscroll-behavior overscroll-behavior-block overscroll-behavior-inline overscroll-behavior-x overscroll-behavior-y

--- a/after/syntax/css/page-floats-3.vim
+++ b/after/syntax/css/page-floats-3.vim
@@ -1,4 +1,3 @@
-syn match cssPositioningProp contained "\<float-\(reference\|defer\|offset\)\>"
-syn match cssPositioningAttr contained "\<inline-\(start\|end\)\>"
-syn match cssPositioningAttr contained "\<snap-\(block\|inline\)\>"
+syn keyword cssPositioningProp contained float-reference float-defer float-offset
+syn keyword cssPositioningAttr contained inline-start inline-end snap-block snap-inline
 syn region cssURL contained matchgroup=cssFunctionName start="\<snap-\(block\|inline\)\s*(" end=")" oneline keepend

--- a/after/syntax/css/pointerevents.vim
+++ b/after/syntax/css/pointerevents.vim
@@ -1,3 +1,2 @@
-syn match cssFontProp contained "\<touch-action\>"
-syn keyword cssFontAttr contained manipulation
-syn match cssFontAttr contained "\<pan-\(x\|y\)\>"
+syn keyword cssFontProp contained touch-action
+syn keyword cssFontAttr contained manipulation pan-x pan-y

--- a/after/syntax/css/position-3.vim
+++ b/after/syntax/css/position-3.vim
@@ -1,2 +1,1 @@
-syn match cssFontProp contained "\<inset\(-\(block\|inline\)\(-\(start\|end\)\)\=\)\=\>"
-syn keyword cssFontAttr contained sticky
+syn keyword cssFontProp contained inset inset-block inset-inline inset-block-start inset-block-end inset-inline-start inset-inline-end

--- a/after/syntax/css/properties-values-api-1.vim
+++ b/after/syntax/css/properties-values-api-1.vim
@@ -1,2 +1,1 @@
-syn keyword cssFontProp contained syntax inherits
-syn match cssFontProp contained "\<initial-value\>"
+syn keyword cssFontProp contained syntax inherits initial-value

--- a/after/syntax/css/pseudo-4.vim
+++ b/after/syntax/css/pseudo-4.vim
@@ -1,3 +1,1 @@
-syn match cssPseudoClassId contained "\<target-text\>"
-syn match cssPseudoClassId contained "\<\(spelling\|grammer\)-error\>"
-syn match cssPseudoClassId contained "\<file-selectors-button\>"
+syn keyword cssPseudoClassId contained target-text spelling-error grammer-error file-selectors-button

--- a/after/syntax/css/regions-1.vim
+++ b/after/syntax/css/regions-1.vim
@@ -1,6 +1,3 @@
-" TODO: create cssRegionsProp group and cssRegionsAttr group
-syn match cssFontProp contained "\<flow-\(into\|from\)\>"
-syn match cssFontProp contained "\<region-fragment\>"
-syn keyword cssFontAttr contained element content break
-syn match cssFontAttr contained "\<\(avoid-\)\=region\>"
+syn keyword cssFontProp contained flow-into flow-from region-fragment
+syn keyword cssFontAttr contained element content break avoid-region region
 syn keyword cssPseudoClassId contained region

--- a/after/syntax/css/rhythm-1.vim
+++ b/after/syntax/css/rhythm-1.vim
@@ -1,3 +1,2 @@
-syn match cssFontProp contained "\<line-height-step\>"
-syn match cssFontProp contained "\<block-step\(-\(size\|insert\|align\|round\)\)\=\>"
+syn keyword cssFontProp contained line-height-step block-step block-step-size block-step-insert block-step-align block-step-round
 syn keyword cssFontAttr contained margin up down nearest

--- a/after/syntax/css/round-display-1.vim
+++ b/after/syntax/css/round-display-1.vim
@@ -1,7 +1,3 @@
-syn match cssFontProp contained "\<shape-inside\>"
-syn match cssFontProp contained "\<border-boundary\>"
-syn match cssFontProp contained "\<polar-\(angle\|distance\)\>"
-syn keyword cssFontAttr contained parent polar
-syn match cssFontAttr contained "\<outside-shape\>"
-syn match cssFontAttr contained "\<shape-box\>"
-syn match cssMediaProp contained /device-radius/
+syn keyword cssFontProp contained shape-inside border-boundary polar-angle polar-distance
+syn keyword cssFontAttr contained parent polar contained outside-shape contained shape-box
+syn keyword cssMediaProp contained device-radius

--- a/after/syntax/css/ruby-1.vim
+++ b/after/syntax/css/ruby-1.vim
@@ -1,4 +1,2 @@
-syn match cssFontProp contained "\<ruby-\(position\|merge\|align\|overhang\)"
-syn keyword cssFontAttr contained merge
-syn match cssFontAttr contained "\<ruby-\(base\|text\)-container\>"
-syn match cssFontAttr contained "\<inter-character\>"
+syn keyword cssFontProp contained merge ruby-position ruby-merge ruby-align ruby-overhang
+syn keyword cssFontAttr contained ruby-base-container ruby-text-container inter-character

--- a/after/syntax/css/scoping-1.vim
+++ b/after/syntax/css/scoping-1.vim
@@ -1,5 +1,4 @@
-syn keyword cssPseudoClassId contained host shadow content
-syn match cssPseudoClassId contained "\<\(scope\|host\)-context\>"
+syn keyword cssPseudoClassId contained host shadow content scope-context host-context
 syn region cssPseudoClassLang matchgroup=cssPseudoClassId start=":\(host\)(" end=")" oneline
 syn match cssSelectorOp2 "/deep/"
 syn match cssFontDescriptor "@scope\>" nextgroup=cssFontDescriptorBlock skipwhite skipnl

--- a/after/syntax/css/scroll-anchoring-1.vim
+++ b/after/syntax/css/scroll-anchoring-1.vim
@@ -1,1 +1,1 @@
-syn match cssFontProp contained "\<overflow-anchor\>"
+syn keyword cssFontProp contained overflow-anchor

--- a/after/syntax/css/scroll-snap-1.vim
+++ b/after/syntax/css/scroll-snap-1.vim
@@ -1,3 +1,2 @@
-syn match cssFontProp contained "\<scroll-snap-\(type\|align\|stop\)\>"
-syn match cssFontProp contained "\<scroll-\(padding\|margin\)\(-\(top\|bottom\|right\|left\|\(block\|inline\)\(-\(end\|start\)\)\=\)\)\=\>"
+syn keyword cssFontProp contained scroll-snap-type scroll-snap-align scroll-snap-stop scroll-padding scroll-margin scroll-padding-top scroll-padding-right scroll-padding-bottom scroll-padding-left scroll-padding-inline-start scroll-padding-block-start scroll-padding-inline-end scroll-padding-block-end scroll-padding-block scroll-padding-inline scroll-margin-top scroll-margin-right scroll-margin-bottom scroll-margin-left scroll-margin-inline-start scroll-margin-block-start scroll-margin-inline-end scroll-margin-block-end scroll-margin-block scroll-margin-inline
 syn keyword cssFontAttr contained x y mandatory proximity

--- a/after/syntax/css/scrollbars-1.vim
+++ b/after/syntax/css/scrollbars-1.vim
@@ -1,1 +1,1 @@
-syn match cssFontProp contained "\<scrollbar-\(color\|width\)\>"
+syn keyword cssFontProp contained scrollbar-color scrollbar-width

--- a/after/syntax/css/selectors-4.vim
+++ b/after/syntax/css/selectors-4.vim
@@ -1,12 +1,3 @@
 syn match cssSelectorOp "[|]"
-syn keyword cssPseudoClassId contained scope current past future default valid required optional blank playing paused defined modal fullscreen seeking buffering stalled muted autofill
-syn match cssPseudoClassId contained "\<\(any\|local\)-link\>"
-syn match cssPseudoClassId contained "\<read-\(only\|write\)\>"
-syn match cssPseudoClassId contained "\<placeholder-shown\>"
-syn match cssPseudoClassId contained "\<\(in\|out-of\)-range\>"
-syn match cssPseudoClassId contained "\<user-\(invalid\|valid\)\>"
-syn match cssPseudoClassId contained "\<target-within\>"
-syn match cssPseudoClassId contained "\<focus-\(within\|visible\)\>"
-syn match cssPseudoClassId contained "\<picture-in-picture\>"
-syn match cssPseudoClassId contained "\<volume-locked\>"
+syn keyword cssPseudoClassId contained scope current past future default valid required optional blank playing paused any-link local-link read-only read-write placeholder-shown in-range out-of-range user-invalid user-valid target-within focus-within focus-visible defined modal fullscreen picture-in-picture seeking buffering stalled muted volume-locked autofill
 syn region cssPseudoClassLang matchgroup=cssPseudoClassId start=":\(is\|dir\|local-link\|current\|nth\(-last\)\=-col\|has\|where\)(" end=")" oneline

--- a/after/syntax/css/shapes-1.vim
+++ b/after/syntax/css/shapes-1.vim
@@ -1,4 +1,3 @@
-" TODO: create cssShapesProp group and cssShapesAttr group
-syn match cssFontProp contained "\<shape-\(outside\|image-threshold\|margin\)\>"
-syn match cssFontAttr contained "\<margin-box\>"
+syn keyword cssFontProp contained shape-outside shape-image-threshold shape-margin
+syn keyword cssFontAttr contained margin-box
 syn region cssFunction contained matchgroup=cssFunctionName start="\<\(inset\|circle\|ellipse\|polygon\)\s*(" end=")" oneline keepend

--- a/after/syntax/css/sizing-3.vim
+++ b/after/syntax/css/sizing-3.vim
@@ -1,2 +1,2 @@
-syn match cssFontAttr contained "\<\(\(min\|max\)-content\)\>"
+syn keyword cssFontAttr contained min-content max-content
 syn region cssFunction contained matchgroup=cssFunctionName start="\<\(fit-content\)\s*(" end=")" oneline keepend

--- a/after/syntax/css/sizing-4.vim
+++ b/after/syntax/css/sizing-4.vim
@@ -1,3 +1,2 @@
-syn match cssFontProp contained "\<contain-intrinsic-size\>"
-syn match cssFontProp contained "\<min-intrinsic-sizing\>"
-syn match cssFontAttr contained "\<zero-if-\(scroll\|extrinsic\)\>"
+syn keyword cssFontProp contained contain-intrinsic-size min-intrinsic-sizing
+syn keyword cssFontAttr contained zero-if-scroll zero-if-extrinsic

--- a/after/syntax/css/speech-1.vim
+++ b/after/syntax/css/speech-1.vim
@@ -1,6 +1,3 @@
-syn match cssAuralProp contained "\<voice-\(volume\|balance\|rate\|pitch\|range\|stress\|duration\)\>"
-syn match cssAuralProp contained "\<rest\(-\(before\|after\)\)\=\>"
-syn keyword cssAuralAttr contained young old neutral preserve moderate reduced
-syn match cssAuralAttr contained "\<\(literal\|no\)-punctuation\>"
-syn match cssAuralAttr contained "\<\(x-\)\=\(weak\|strong\)\>"
+syn keyword cssAuralProp contained voice-volume voice-balance voice-rate voice-pitch voice-range voice-stress voice-duration rest rest-before rest-after
+syn keyword cssAuralAttr contained young old neutral preserve moderate reduced literal-punctuation no-punctuation weak x-weak strong x-strong
 syn match cssValueNumber contained "[-+]\=\d\+\(dB\|st\)"

--- a/after/syntax/css/svg2.vim
+++ b/after/syntax/css/svg2.vim
@@ -1,15 +1,4 @@
 syn keyword cssTagName animate animateMotion animateTransform circle clipPath cursor defs desc discard ellipse feBlend feColorMatrix feComponentTransfer feComposite feConvolveMatrix feDiffuseLighting feDisplacementMap feDistantLight feDropShadow feFlood feFuncA feFuncB feFuncG feFuncR feGaussianBlur feImage feMerge feMergeNode feMorphology feOffset fePointLight feSpecularLighting feSpotLight feTile feTurbulence filter foreignObject g hatch hatchpath image line linearGradient marker mesh meshgradient meshpatch meshrow metadata mpath path pattern polygon polyline radialGradient rect set solidcolor stop switch symbol text textPath tspan unknown use view
-syn keyword cssFontProp contained cx cy d r rx ry x y
-syn match cssFontProp contained "\<color-\(interpolation\|rendering\)\>"
-syn match cssFontProp contained "\<marker-\(end\|mid\|start\)\>"
-syn match cssFontProp contained "\<shape-rendering\>"
-syn match cssFontProp contained "\<solid-\(color\|opacity\)\>"
-syn match cssFontProp contained "\<stop-\(color\|opacity\)\>"
-syn match cssFontProp contained "\<text-anchor\>"
-syn match cssFontProp contained "\<vector-effect\>"
-syn keyword cssFontAttr contained crispEdges geometricPrecision optimizeQuality viewport
-syn match cssFontAttr contained "\<context-\(fill\|stroke\)\>"
-syn match cssFontAttr contained "\<fixed-position\>"
-syn match cssFontAttr contained "\<miter\(-clip\)\=\>"
-syn match cssFontAttr contained "\<non-\(scaling-stroke\|scaling-size\|rotation\)\>"
+syn keyword cssFontProp contained cx cy d r rx ry x y color-interpolation color-rendering marker-end marker-mid marker-start shape-rendering solid-color solid-opacity stop-color stop-opacity text-anchor vector-effect
+syn keyword cssFontAttr contained crispEdges geometricPrecision optimizeQuality viewport context-fill context-stroke fixed-position miter miter-clip non-scaling-stroke non-scaling-size non-rotation
 syn region cssFunction contained matchgroup=cssFunctionName start="\<\(child\|icc-color\)\s*(" end=")" oneline keepend

--- a/after/syntax/css/text-3.vim
+++ b/after/syntax/css/text-3.vim
@@ -1,8 +1,2 @@
-syn match cssTextProp contained "\<tab-size\>"
-syn match cssTextProp contained "\<text-align-all\>"
-syn keyword cssTextAttr contained loose strict hanging anywhere
-syn match cssTextAttr contained "\<match-parent\>"
-syn match cssTextAttr contained "\<each-line\>"
-syn match cssTextAttr contained "\<full-width\>"
-syn match cssTextAttr contained "\<justify-all\>"
-syn match cssTextAttr contained "\<break-spaces\>"
+syn keyword cssTextProp contained tab-size text-align-all
+syn keyword cssTextAttr contained loose strict hanging anywhere match-parent each-line full-width justify-all break-spaces

--- a/after/syntax/css/text-4.vim
+++ b/after/syntax/css/text-4.vim
@@ -1,18 +1,2 @@
-syn match cssTextProp contained "\<text-space-\(collapse\|trim\)\>"
-syn match cssTextProp contained "\<text-\(wrap\|spacing\|group-align\)\>"
-syn match cssTextProp contained "\<wrap-\(before\|after\|inside\)\>"
-syn match cssTextProp contained "\<hyphenate-\(character\|limit-\(zone\|chars\|lines\|last\)\)\>"
-syn match cssTextProp contained "\<line-padding\>"
-syn match cssTextProp contained "\<word-boundary-\(detection\|expansion\)\>"
-syn keyword cssTextAttr contained spread punctuation
-syn match cssTextAttr contained "\<preserve-\(breaks\|spaces\)\>"
-syn match cssTextAttr contained "\<trim-inner\>"
-syn match cssTextAttr contained "\<discard-\(before\|after\)\>"
-syn match cssTextAttr contained "\<avoid-\(line\|flex\)\>"
-syn match cssTextAttr contained "\<pre-wrap-auto\>"
-syn match cssTextAttr contained "\<no-limit\>"
-syn match cssTextAttr contained "\<\(trim\|space\)-\(start\|end\|adjacent\)\>"
-syn match cssTextAttr contained "\<space-first\>"
-syn match cssTextAttr contained "\<no-compress\>"
-syn match cssTextAttr contained "\<ideograph-\(alpha\|numeric\)\>"
-syn match cssTextAttr contained "\<ideographic-space\>"
+syn keyword cssTextProp contained text-space-collapse text-space-trim text-wrap text-spacing text-group-align wrap-before wrap-after wrap-inside hyphenate-character hyphenate-limit-zone hyphenate-limit-chars hyphenate-limit-lines hyphenate-limit-last line-padding word-boundary-detection word-boundary-expansion
+syn keyword cssTextAttr contained spread punctuation preserve-breaks preserve-spaces trim-inner discard-before discard-after avoid-line avoid-flex pre-wrap-auto no-limit trim-start trim-end trim-adjacent space-start space-end space-adjacent space-first no-compress ideograph-alpha ideograph-numeric ideographic-space

--- a/after/syntax/css/text-decor-3.vim
+++ b/after/syntax/css/text-decor-3.vim
@@ -1,2 +1,2 @@
-syn match cssTextProp contained "\<text-\(decoration\(-\(color\|line\|style\)\)\=\|underline-position\|emphasis\(-\(color\|position\|style\)\)\=\)\>"
+syn keyword cssTextProp contained text-decoration-color text-decoration-line text-decoration-style text-emphasis text-emphasis-color text-emphasis-position text-emphasis-style
 syn keyword cssTextAttr contained wavy alphabetic ink under filled dot triangle sesame over

--- a/after/syntax/css/text-decor-4.vim
+++ b/after/syntax/css/text-decor-4.vim
@@ -1,6 +1,2 @@
-syn match cssTextProp contained "\<text-\(decoration-\(thickness\|skip\|skip-ink\)\|underline-offset\|emphasis-skip\)\>"
-syn keyword cssTextAttr contained objects edges symbols narrow
-syn match cssTextAttr contained "\<\(spelling\|grammer\)-error\>"
-syn match cssTextAttr contained "\<from-font\>"
-syn match cssTextAttr contained "\<\(\(leading\|trailing\)-\)\=spaces\>"
-syn match cssTextAttr contained "\<box-decoration\>"
+syn keyword cssTextProp contained text-decoration-thickness text-underline-offset text-decoration-skip text-decoration-skip-ink text-emphasis-skip
+syn keyword cssTextAttr contained objects edges symbols narrow spelling-error grammer-error from-font spaces leading-spaces trailing-spaces box-decoration

--- a/after/syntax/css/transforms-1.vim
+++ b/after/syntax/css/transforms-1.vim
@@ -1,1 +1,1 @@
-syn match cssFontProp contained "\<transform-box\>"
+syn keyword cssFontProp contained transform-box

--- a/after/syntax/css/ui-3.vim
+++ b/after/syntax/css/ui-3.vim
@@ -1,2 +1,2 @@
-syn match cssUIProp contained "\<caret-color\>"
+syn keyword cssUIProp contained caret-color
 syn keyword cssUIAttr contained grab grabbing

--- a/after/syntax/css/ui-4.vim
+++ b/after/syntax/css/ui-4.vim
@@ -1,3 +1,3 @@
-syn match cssUIProp contained "\<caret\(-shape\)\=\>"
+syn keyword cssUIProp contained caret caret-shape
 syn keyword cssUIAttr contained fade underscore
 syn region cssFunction contained matchgroup=cssFunctionName start="\<fade\s*(" end=")" oneline keepend

--- a/after/syntax/css/unofficials.vim
+++ b/after/syntax/css/unofficials.vim
@@ -1,2 +1,5 @@
-syn match cssFontProp contained "\<backdrop-filter\>"
+" https://drafts.fxtf.org/filter-effects-2/
+syn keyword cssFontProp contained backdrop-filter
+
+" https://drafts.csswg.org/css-env-1/
 syn region cssFunction contained matchgroup=cssFunctionName start="\<env\s*(" end=")" oneline keepend

--- a/after/syntax/css/will-change-1.vim
+++ b/after/syntax/css/will-change-1.vim
@@ -1,3 +1,2 @@
-" TODO: create cssWillChangeProp group and cssWillChangeAttr group
-syn match cssFontProp contained "\<will-change\>"
-syn match cssFontAttr contained "\<scroll-position\>"
+syn keyword cssFontProp contained will-change
+syn keyword cssFontAttr contained scroll-position

--- a/after/syntax/css/writing-modes-3.vim
+++ b/after/syntax/css/writing-modes-3.vim
@@ -1,7 +1,2 @@
-syn match cssFontProp contained "\<writing-mode\>"
-syn match cssFontProp contained "\<text-\(orientation\|combine-upright\)\>"
-syn match cssFontProp contained "\<glyph-orientation-vertical\>"
-syn keyword cssFontAttr contained before after mixed upright plaintext sideways
-syn match cssFontAttr contained "\<isolate\(-override\)\=\>"
-syn match cssFontAttr contained "\<horizontal-tb\>"
-syn match cssFontAttr contained "\<vertical-\(rl\|lr\)\>"
+syn keyword cssFontProp contained writing-mode text-orientation text-combine-upright glyph-orientation-vertical
+syn keyword cssFontAttr contained before after mixed upright plaintext sideways isolate isolate-override horizontal-tb vertical-rl vertical-lr

--- a/after/syntax/css/writing-modes-4.vim
+++ b/after/syntax/css/writing-modes-4.vim
@@ -1,1 +1,1 @@
-syn match cssFontAttr contained "\<sideways-\(rl\|lr\)\>"
+syn keyword cssFontAttr contained sideways-rl sideways-lr

--- a/test/test.css
+++ b/test/test.css
@@ -3,12 +3,10 @@
 	place-content: auto;
 	place-items: auto;
 	row-gap: auto;
-	gap: auto;
 	display: safe;
 	display: unsafe;
 	display: self-start;
 	display: self-end;
-	display: space-evenly;
 	display: legacy;
 }
 
@@ -455,7 +453,6 @@
 }
 
 .html5,
-picture,
 rb,
 rtc,
 slot,
@@ -464,12 +461,9 @@ template {
 }
 
 .images-3 {
-	object-fit: auto;
-	object-position: auto;
 	image-orientation: auto;
 	display: snap;
 	display: flip;
-	display: scale-down;
 	display: from-image;
 	display: pixelated;
 	display: repeating-linear-gradient(to bottom, yellow, blue);
@@ -480,7 +474,6 @@ template {
 	image-resolution: auto;
 	display: image("sprite.svg#xywh=40,0,20,20");
 	display: element(#test);
-	display: conic-gradient(at 25% 30%, white, black 60%);
 }
 
 .inline-3 {
@@ -704,7 +697,6 @@ mask {
 	inset-block: auto;
 	inset-inline: auto;
 	inset: auto;
-	display: sticky;
 }
 
 .properties-values-api-1 {


### PR DESCRIPTION
The official CSS syntax file was updated to include hyphen in `iskeyword`. So, vim-css3-syantax can use `keyword` instead of `match`.